### PR TITLE
Check .repo file exists before trying to stat

### DIFF
--- a/lib/puppet/provider/yumrepo/inifile.rb
+++ b/lib/puppet/provider/yumrepo/inifile.rb
@@ -191,7 +191,7 @@ Puppet::Type.type(:yumrepo).provide(:inifile) do
         current_mode = Puppet::FileSystem.stat(file).mode & 0777
         unless current_mode == target_mode
           resource.info _("changing mode of %{file} from %{current_mode} to %{target_mode}") %
-                          { file: file, current_mode: "%03o" % current_mode, target_mode: "%03o" % target_mode }
+                            { file: file, current_mode: "%03o" % current_mode, target_mode: "%03o" % target_mode }
           Puppet::FileSystem.chmod(target_mode, file)
         end
       end

--- a/lib/puppet/provider/yumrepo/inifile.rb
+++ b/lib/puppet/provider/yumrepo/inifile.rb
@@ -187,11 +187,13 @@ Puppet::Type.type(:yumrepo).provide(:inifile) do
 
     target_mode = 0644
     inifile.each_file do |file|
-      current_mode = Puppet::FileSystem.stat(file).mode & 0777
-      unless current_mode == target_mode
-        resource.info _("changing mode of %{file} from %{current_mode} to %{target_mode}") %
+      if Puppet::FileSystem.exist?(file)
+        current_mode = Puppet::FileSystem.stat(file).mode & 0777
+        unless current_mode == target_mode
+          resource.info _("changing mode of %{file} from %{current_mode} to %{target_mode}") %
                           { file: file, current_mode: "%03o" % current_mode, target_mode: "%03o" % target_mode }
-        Puppet::FileSystem.chmod(target_mode, file)
+          Puppet::FileSystem.chmod(target_mode, file)
+        end
       end
     end
   end


### PR DESCRIPTION
If a yum repo file is removed mid-run (e.g. by a yum plugin), any yumrepo resource changes may fail with a "No such file or directory @ rb_file_stat" error because the files array is not refreshed before store() attempts to stat a file that no longer exists.